### PR TITLE
Allow XPath query to find the version node for projects with a default namespace (EG: Xamarin Android)

### DIFF
--- a/MSBump/BumpVersion.cs
+++ b/MSBump/BumpVersion.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Microsoft.Build.Framework;
@@ -77,7 +78,14 @@ namespace MSBump
 
         private bool TryBump(XDocument proj, string tagName, Settings settings)
         {
-            var element = proj.Root.XPathSelectElement("PropertyGroup/" + tagName);
+	        var defaultNamespace = proj.Root.GetDefaultNamespace();
+	        var defaultNamespacePrefix = "ns";
+	        var xmlNamespaceManager = new XmlNamespaceManager(new NameTable());
+
+	        xmlNamespaceManager.AddNamespace(defaultNamespacePrefix, defaultNamespace.NamespaceName);
+
+	        var element = proj.Root.XPathSelectElement($"{defaultNamespacePrefix}:PropertyGroup/{defaultNamespacePrefix}:{tagName}");
+
             if (element == null)
                 return false;
             var oldVersion = new NuGetVersion(element.Value);

--- a/MSBump/BumpVersion.cs
+++ b/MSBump/BumpVersion.cs
@@ -84,7 +84,7 @@ namespace MSBump
 
 	        xmlNamespaceManager.AddNamespace(defaultNamespacePrefix, defaultNamespace.NamespaceName);
 
-	        var element = proj.Root.XPathSelectElement($"{defaultNamespacePrefix}:PropertyGroup/{defaultNamespacePrefix}:{tagName}");
+	        var element = proj.Root.XPathSelectElement($"{defaultNamespacePrefix}:PropertyGroup/{defaultNamespacePrefix}:{tagName}", xmlNamespaceManager);
 
             if (element == null)
                 return false;


### PR DESCRIPTION
This allows for version XPath query of projects that have default namespace, as the below with `xmlns="http://schemas.microsoft.com/developer/msbuild/2003"`:

```
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup>
    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
    <ProductVersion>8.0.30703</ProductVersion>
    <SchemaVersion>2.0</SchemaVersion>
    <ProjectGuid>{7C6C3982-A053-4A94-8A45-0B8E2B1B4A0F}</ProjectGuid>
    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
    <OutputType>Library</OutputType>
    <AppDesignerFolder>Properties</AppDesignerFolder>
    <RootNamespace>MyCo.Droid</RootNamespace>
    <AssemblyName>MyCo.Android</AssemblyName>
    <Version>1.0.0</Version>
    <Authors>My Co</Authors>
    <Company>My Co, LLC</Company>
    <Description>Example description</Description>
    <FileAlignment>512</FileAlignment>
    <AndroidApplication>true</AndroidApplication>
    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
    <AndroidStoreUncompressedFileExtensions />
    <MandroidI18n />
    <JavaMaximumHeapSize />
    <JavaOptions />
    <NuGetPackageImportStamp />
  </PropertyGroup>

  <!-- some other stuff... -->
</Project>
```

... but maintains the backward compatibility of the version query to newer (EG: .NET Standard) project types without default namespaces, such as:

```
<?xml version="1.0" encoding="utf-8"?>
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard1.4</TargetFramework>
    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
    <Version>1.0.0</Version>
    <Authors>My Co</Authors>
    <Company>My Co, LLC</Company>
    <Description>Example description</Description>
    <PackageId>MyCo.Common</PackageId>
    <NeutralLanguage>en</NeutralLanguage>
    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
  </PropertyGroup>

  <!-- some other stuff... -->  
</Project>
```