### PR TITLE
Added version bump implementation for netcoreapp2.0 AssemblyVersion

### DIFF
--- a/MSBump/BumpVersion.cs
+++ b/MSBump/BumpVersion.cs
@@ -40,10 +40,10 @@ namespace MSBump
                                         LabelDigits = LabelDigits == 0 ? Settings.DefaultLabelDigits : LabelDigits
                                     };
 
-				Log.LogMessage(MessageImportance.Low, $"MSBump settings = {JObject.FromObject(settings).ToString()}");
+                Log.LogMessage(MessageImportance.Low, $"MSBump settings = {JObject.FromObject(settings).ToString()}");
 
-				if (TryBump(proj, "Version", settings) | TryBump(proj, "AssemblyVersion", settings))
-				{
+                if (TryBump(proj, "Version", settings) | TryBump(proj, "AssemblyVersion", settings))
+                {
                     Log.LogMessage(MessageImportance.Low, "Saving project file");
                     using (var stream = File.Create(ProjectPath))
                     {
@@ -203,7 +203,7 @@ namespace MSBump
         [Output]
         public string NewVersion { get; set; }
 
-		[Output]
-		public string NewAssemblyVersion { get; set; }
+        [Output]
+        public string NewAssemblyVersion { get; set; }
 	}
 }

--- a/MSBump/BumpVersion.cs
+++ b/MSBump/BumpVersion.cs
@@ -40,10 +40,10 @@ namespace MSBump
                                         LabelDigits = LabelDigits == 0 ? Settings.DefaultLabelDigits : LabelDigits
                                     };
 
-                Log.LogMessage(MessageImportance.Low, $"MSBump settings = {JObject.FromObject(settings).ToString()}");
+				Log.LogMessage(MessageImportance.Low, $"MSBump settings = {JObject.FromObject(settings).ToString()}");
 
-                if (TryBump(proj, "Version", settings))
-                {
+				if (TryBump(proj, "Version", settings) | TryBump(proj, "AssemblyVersion", settings))
+				{
                     Log.LogMessage(MessageImportance.Low, "Saving project file");
                     using (var stream = File.Create(ProjectPath))
                     {
@@ -202,5 +202,8 @@ namespace MSBump
 
         [Output]
         public string NewVersion { get; set; }
-    }
+
+		[Output]
+		public string NewAssemblyVersion { get; set; }
+	}
 }

--- a/MSBump/build/MSBump.targets
+++ b/MSBump/build/MSBump.targets
@@ -20,11 +20,13 @@
       LabelDigits="$(BumpLabelDigits)">
 
       <Output TaskParameter="NewVersion" PropertyName="MSBumpNewVersion" />
+      <Output TaskParameter="NewAssemblyVersion" PropertyName="MSBumpNewAssemblyVersion" />
     </BumpVersion>
     
     <PropertyGroup>
       <Version Condition="$(MSBumpNewVersion) != ''">$(MSBumpNewVersion)</Version>
       <PackageVersion Condition="$(MSBumpNewVersion) != ''">$(MSBumpNewVersion)</PackageVersion>
+      <AssemblyVersion Condition="$(MSBumpNewAssemblyVersion) != ''">$(MSBumpNewAssemblyVersion)</AssemblyVersion>
     </PropertyGroup>
 
   </Target>

--- a/MSBump/buildMultiTargeting/MSBump.targets
+++ b/MSBump/buildMultiTargeting/MSBump.targets
@@ -22,11 +22,13 @@
       LabelDigits="$(BumpLabelDigits)">
 
       <Output TaskParameter="NewVersion" PropertyName="MSBumpNewVersion" />
+      <Output TaskParameter="NewAssemblyVersion" PropertyName="MSBumpNewAssemblyVersion" />
     </BumpVersion>
 
     <PropertyGroup>
       <Version Condition="$(MSBumpNewVersion) != ''">$(MSBumpNewVersion)</Version>
       <PackageVersion Condition="$(MSBumpNewVersion) != ''">$(MSBumpNewVersion)</PackageVersion>
+      <AssemblyVersion Condition="$(MSBumpNewAssemblyVersion) != ''">$(MSBumpNewAssemblyVersion)</AssemblyVersion>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
The following request came in to bump AssemblyVersion for netcoreapp2.0:

```
I am using .Net Core 2.0 for the first time and the .csproj has <AssemblyVersion> and <FileVersion> but no <Version>. Would it be possible to check and see if 

<TargetFramework>netcoreapp2.0</TargetFramework>

And update AssemblyVersion instead of just Version?
```